### PR TITLE
Update __init__.py

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -231,7 +231,7 @@ class KoboMetadata(Source):
         result_queue.put((self, cover))
 
     def _get_search_url(self, search_str: str, page_number: int) -> str:
-        query = {"query": search_str, "fcmedia": "Book", "pageNumber": page_number}
+        query = {"query": search_str, "fcmedia": "Book", "pageNumber": page_number, "fclanguages": "all"}
         return f"{self.BASE_URL}{self.prefs['country']}/en/search?{urlencode(query)}"
 
     def _generate_query(self, title: str, authors: list[str]) -> str:


### PR DESCRIPTION
Searching for cover with country "Italy" `https://www.kobo.com/it/en/search?query=` result are redirected with param `&fclanguages=en` that not have results. Forcing &fclanguages=all give back result for queried book