### PR TITLE
Increase support for light novels and Japanese Kobo

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -119,8 +119,9 @@ class KoboMetadata(Source):
             _("Resize cover"),
             _("Resize the cover to the maximum_cover_size tweak setting"),
         ),
-        Option("use_author", "bool", True, ("Use author information for search?"), ("Use author information for the search of metadata/cover when selected; recommended for light novels")),
-        Option("only_light_novels", "bool", False, ("Use Light Novel tag? (!Only usable on japanese Kobo)"), ("USe Light Novel tag for the search to avoid same named mangas."))
+        Option("differentiate_kobo_isbn", "bool", False, ("Differentiate between Kobo ID and ISBN?"), ("Do not falsely write Kobo ID as ISBN.")),
+        Option("use_author", "bool", True, ("Use author information for search?"), ("Use author information for the search of metadata/cover when selected; recommended for light novels.")),
+        Option("only_light_novels", "bool", False, ("Use Light Novel tag? (!Only usable on japanese Kobo)"), ("Use Light Novel tag for the search to avoid same named mangas."))
     )
 
     _impl = None
@@ -146,9 +147,13 @@ class KoboMetadata(Source):
 
     def get_cached_cover_url(self, identifiers):
         isbn = identifiers.get("isbn", None)
+        kobo = identifiers.get("kobo", None)
 
         if isbn is not None:
             return self.cached_identifier_to_cover_url(isbn)
+        
+        if kobo is not None:
+            return self.cached_identifier_to_cover_url(kobo)
 
         return None
 

--- a/__init__.py
+++ b/__init__.py
@@ -119,6 +119,7 @@ class KoboMetadata(Source):
             _("Resize cover"),
             _("Resize the cover to the maximum_cover_size tweak setting"),
         ),
+        Option("use_author", "bool", True, ("Use author information for search?"), ("Use author information for the search of metadata/cover when selected; recommended for light novels")),
     )
 
     _impl = None

--- a/__init__.py
+++ b/__init__.py
@@ -120,6 +120,7 @@ class KoboMetadata(Source):
             _("Resize the cover to the maximum_cover_size tweak setting"),
         ),
         Option("use_author", "bool", True, ("Use author information for search?"), ("Use author information for the search of metadata/cover when selected; recommended for light novels")),
+        Option("only_light_novels", "bool", False, ("Use Light Novel tag? (!Only usable on japanese Kobo)"), ("USe Light Novel tag for the search to avoid same named mangas."))
     )
 
     _impl = None

--- a/kobo_metadata.py
+++ b/kobo_metadata.py
@@ -32,9 +32,9 @@ class KoboMetadataImpl:
     
     def get_kobo_url(self, kobo_id: str, prefs: Dict[str, any]) -> str:
         if prefs['language'] == 'all':
-            url = f"{self.BASE_URL}{prefs['country']}/ebook/{kobo_id}"
+            url = f"{self.BASE_URL}{prefs['country']}/search?query={kobo_id}"
         else:
-            url = f"{self.BASE_URL}{prefs['country']}/{prefs['language']}/ebook/{kobo_id}"
+            url = f"{self.BASE_URL}{prefs['country']}/{prefs['language']}/search?query={kobo_id}"
         return url
     
     @staticmethod

--- a/kobo_metadata.py
+++ b/kobo_metadata.py
@@ -36,6 +36,12 @@ class KoboMetadataImpl:
         else:
             url = f"{self.BASE_URL}{prefs['country']}/{prefs['language']}/ebook/{kobo_id}"
         return url
+    
+    @staticmethod
+    def check_isbn_valid(isbn: str) -> bool:
+        if not isbn:
+            return False
+        return isbn[:3] == "978" or isbn[:3] == "979"
 
     def identify(
         self,
@@ -99,6 +105,10 @@ class KoboMetadataImpl:
         isbn = check_isbn(identifiers.get("isbn", None))
         if isbn:
             urls.extend(self._perform_isbn_search(isbn, 1, prefs, timeout, log))
+
+        kobo = identifiers.get("kobo", None)
+        if kobo:
+            urls.append(self.get_kobo_url(kobo, prefs))
 
         # Only go looking for more matches if we couldn't match isbn
         if not urls:
@@ -292,6 +302,7 @@ class KoboMetadataImpl:
             for x in book_details_elements[1:]:
                 descriptor = x.text.strip()
                 data = x.xpath("span")[0].text if x.xpath("span") else None
+
                 if descriptor == "Release Date:" or descriptor == "発売日：": # japanese colon is different
                     if prefs["language"] == "ja":
                         date_match = re.match("(\d{4})年(\d{1,2})月(\d{1,2})日", data)
@@ -299,9 +310,15 @@ class KoboMetadataImpl:
                     if data:
                         metadata.pubdate = parse_only_date(data)
                         log.info(f"KoboMetadata::parse_book_page: Got pubdate: {metadata.pubdate}")
+
                 elif descriptor == "ISBN:" or descriptor == "Book ID:" or descriptor == "書籍ID：":
-                    metadata.isbn = x.xpath("span")[0].text
-                    log.info(f"KoboMetadata::parse_book_page: Got isbn: {metadata.isbn}")
+                    if prefs["differentiate_kobo_isbn"] and not KoboMetadataImpl.check_isbn_valid(data):
+                        metadata.set_identifier('kobo', data)
+                        log.info(f"KoboMetadata::parse_book_page: Got kobo book id: {data}")
+                    else:
+                        metadata.isbn = data
+                        log.info(f"KoboMetadata::parse_book_page: Got isbn: {metadata.isbn}")
+
                 elif descriptor == "Language:" or descriptor == "言語：":
                     if prefs["language"] == "ja":
                         # Assuming JP store will be mainly used for JP books, otherwise to much baggage to add all languages
@@ -325,7 +342,7 @@ class KoboMetadataImpl:
 
         cover_url = self._parse_book_page_for_cover(page, prefs, log)
         if cover_url:
-            self.plugin.cache_identifier_to_cover_url(metadata.isbn, cover_url)
+            self.plugin.cache_identifier_to_cover_url(metadata.isbn if metadata.isbn else metadata.identifiers['kobo'], cover_url)
 
         blacklisted_title = self._check_title_blacklist(title, prefs, log)
         if blacklisted_title:

--- a/kobo_metadata.py
+++ b/kobo_metadata.py
@@ -26,6 +26,8 @@ class KoboMetadataImpl:
 
     def get_search_url(self, search_str: str, page_number: int, prefs: Dict[str, any]) -> str:
         query = {"query": search_str, "fcmedia": "Book", "pageNumber": page_number, "fclanguages": prefs["language"]}
+        if prefs["only_light_novels"]:
+            query["id"] = "dac63710-e136-4309-ac7f-d517e2202171" # Kobo tag for light novels
         return f"{self.BASE_URL}{prefs['country']}/{prefs['language']}/search?{urlencode(query)}"
     
     def get_kobo_url(self, kobo_id: str, prefs: Dict[str, any]) -> str:
@@ -278,9 +280,9 @@ class KoboMetadataImpl:
 
             series_index_element = series_elements[-1].xpath("span[@class='sequenced-name-prefix']")
             if series_index_element:
-                series_index_match = re.match("Book (.*) - ", series_index_element[0].text)
+                series_index_match = re.match("(本:|Book) (.*) - ", series_index_element[0].text)
                 if series_index_match:
-                    metadata.series_index = series_index_match.groups(0)[0]
+                    metadata.series_index = series_index_match.groups(0)[1]
                     log.info(f"KoboMetadata::parse_book_page: Got series_index: {metadata.series_index}")
 
         book_details_elements = page.xpath("//div[@class='bookitem-secondary-metadata']/ul/li")
@@ -289,14 +291,22 @@ class KoboMetadataImpl:
             log.info(f"KoboMetadata::parse_book_page: Got publisher: {metadata.publisher}")
             for x in book_details_elements[1:]:
                 descriptor = x.text.strip()
-                if descriptor == "Release Date:":
-                    metadata.pubdate = parse_only_date(x.xpath("span")[0].text)
-                    log.info(f"KoboMetadata::parse_book_page: Got pubdate: {metadata.pubdate}")
-                elif descriptor == "ISBN:" or descriptor == "Book ID:":
+                data = x.xpath("span")[0].text if x.xpath("span") else None
+                if descriptor == "Release Date:" or descriptor == "発売日：": # japanese colon is different
+                    if prefs["language"] == "ja":
+                        date_match = re.match("(\d{4})年(\d{1,2})月(\d{1,2})日", data)
+                        data = f"{date_match.groups(0)[0]}-{date_match.groups(0)[1]}-{date_match.groups(0)[2]}"
+                    if data:
+                        metadata.pubdate = parse_only_date(data)
+                        log.info(f"KoboMetadata::parse_book_page: Got pubdate: {metadata.pubdate}")
+                elif descriptor == "ISBN:" or descriptor == "Book ID:" or descriptor == "書籍ID：":
                     metadata.isbn = x.xpath("span")[0].text
                     log.info(f"KoboMetadata::parse_book_page: Got isbn: {metadata.isbn}")
-                elif descriptor == "Language:":
-                    metadata.language = x.xpath("span")[0].text
+                elif descriptor == "Language:" or descriptor == "言語：":
+                    if prefs["language"] == "ja":
+                        # Assuming JP store will be mainly used for JP books, otherwise to much baggage to add all languages
+                        data = "Japanese" if data == "日本語" else "English" 
+                    metadata.language = data
                     log.info(f"KoboMetadata::parse_book_page: Got language: {metadata.language}")
 
         tags_elements = page.xpath("//ul[@class='category-rankings']/meta[@property='genre']")

--- a/kobo_metadata.py
+++ b/kobo_metadata.py
@@ -202,7 +202,7 @@ class KoboMetadataImpl:
             for x in self.plugin.get_title_tokens(title, strip_joiners=False, strip_subtitle=False)
         )
 
-        if authors:
+        if authors and prefs["use_author"]:
             title += " " + " ".join(self.plugin.get_author_tokens(authors))
 
         return title

--- a/kobo_metadata.py
+++ b/kobo_metadata.py
@@ -26,8 +26,8 @@ class KoboMetadataImpl:
 
     def get_search_url(self, search_str: str, page_number: int, prefs: Dict[str, any]) -> str:
         query = {"query": search_str, "fcmedia": "Book", "pageNumber": page_number, "fclanguages": prefs["language"]}
-        if prefs["only_light_novels"]:
-            query["id"] = "dac63710-e136-4309-ac7f-d517e2202171" # Kobo tag for light novels
+        if prefs["only_light_novels"] and prefs["language"] == "ja" and prefs["country"] == "jp":
+            query["id"] = "dac63710-e136-4309-ac7f-d517e2202171" # Kobo tag for light novels in the Japanese store
         return f"{self.BASE_URL}{prefs['country']}/{prefs['language']}/search?{urlencode(query)}"
     
     def get_kobo_url(self, kobo_id: str, prefs: Dict[str, any]) -> str:

--- a/kobo_metadata.py
+++ b/kobo_metadata.py
@@ -65,7 +65,7 @@ class KoboMetadataImpl:
 
         if isbn:
             log.info(f"Searching with ISBN: {isbn}")
-            id_urls.extend(self._perform_isbn_search(isbn, prefs["num_matches"], prefs, timeout, log))
+            id_urls.append(self.get_kobo_url(isbn, prefs))
 
         if id_urls:
             unique_id_urls = list(dict.fromkeys(id_urls))


### PR DESCRIPTION
This pull request implements features that increase the reliabilty for finding the metadata of Light Novels enormously.

For this an use_author flag option was added which allows the user decide wether to include the author in the generated search term. The default is on but the recommendation for Light Novels is off.
Additionally support for the Japanese UI (for some reason you get kind of almost random results when using the Japanese store with English UI) and an option to potentially add a search limitation to the Light Novels category (Japanese Store only) was added.

Finally, the option to differentiate between Kobo ID and ISBN was added, this allows to avoid errors in the metadata UI and better organization as especially Japanese Kobo often uses non-ISBN entries for their ebooks.

All options default so that the current behavior is not changed. If the options are (partially) enabled it also resolves #12. 

PS: Accidentally seem to have had my whitespace settings wrong (and my local git ignores whitespace diffs), I can also redo this if necessary. It is possible to hide whitespace-onlt changes by appending _w=1_ as parameter to the url.